### PR TITLE
rcasm didn't catch 2 short branches to a loc'n in another page

### DIFF
--- a/yr.asm
+++ b/yr.asm
@@ -1061,12 +1061,13 @@ loop1024:  sep     r7                  ; receive expected packets to buffer
            bnz     loop1024
 
            ghi     rb
-checkbuf:  SERN    rcverror
+checkbuf:  SERN    rcverrsh
            smi     1 
-           SERN    rcverror
+           SERN    rcverrsh
            bnz     checkbuf
 
            lbr     received
+rcverrsh:  lbr     rcverror
 
 ; Input
 ;


### PR DESCRIPTION
RcAsm wasn't catching a couple of short branches around 'checkbuf' (at 266C and 2670) to 'rcverror' (at 2081). I only noticed it when I was trying to assemble the source with a18.